### PR TITLE
derive copy for Interrupt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ use core::ops::Deref;
 pub mod interrupt {
     use core::convert::TryFrom;
     #[doc = r" Enumeration of all the interrupts"]
+    #[derive(Copy, Clone)]
     pub enum Interrupt {
         #[doc = "1 - WATCHDOG"]
         WATCHDOG,


### PR DESCRIPTION
This makes it easier to have debug printing in rtfm example, otherwise I was getting the error:

```
cargo build --examples
   Compiling riscv-crates v0.1.0 (file:///Users/bradjc/git/riscv-crates)
error[E0382]: use of moved value: `intr`
   --> examples/rtfm.rs:183:37
    |
181 |                 debug_print_numtoa!(intr.unwrap(), 10);
    |                                     ---- value moved here
182 |                 debug_print!(b"\n");
183 |                 plic.claim.complete(intr.unwrap());
    |                                     ^^^^ value used here after move
    |
    = note: move occurs because `intr` has type `core::option::Option<hifive::e310x_hal::e310x::Interrupt>`, which does not implement the `Copy` trait

error: aborting due to previous error

For more information about this error, try `rustc --explain E0382`.
error: Could not compile `riscv-crates`.

To learn more, run the command again with --verbose.
make: *** [build] Error 101
```