### PR TITLE
Fix delay0 and delay1 reset value

### DIFF
--- a/e310x.svd
+++ b/e310x.svd
@@ -1854,7 +1854,7 @@
           <name>delay1</name>
           <description>Delay Control 1 Register</description>
           <addressOffset>0x2C</addressOffset>
-          <resetValue>0x0001</resetValue>
+          <resetValue>0x00000001</resetValue>
           <fields>
             <field>
               <name>interxfr</name>

--- a/e310x.svd
+++ b/e310x.svd
@@ -1836,6 +1836,7 @@
           <name>delay0</name>
           <description>Delay Control 0 Register</description>
           <addressOffset>0x28</addressOffset>
+          <resetValue>0x0101</resetValue>
           <fields>
             <field>
               <name>sckcs</name>
@@ -1853,6 +1854,7 @@
           <name>delay1</name>
           <description>Delay Control 1 Register</description>
           <addressOffset>0x2C</addressOffset>
+          <resetValue>0x0001</resetValue>
           <fields>
             <field>
               <name>interxfr</name>

--- a/e310x.svd
+++ b/e310x.svd
@@ -1836,7 +1836,7 @@
           <name>delay0</name>
           <description>Delay Control 0 Register</description>
           <addressOffset>0x28</addressOffset>
-          <resetValue>0x0101</resetValue>
+          <resetValue>0x00010001</resetValue>
           <fields>
             <field>
               <name>sckcs</name>

--- a/src/common/qspi0/delay0.rs
+++ b/src/common/qspi0/delay0.rs
@@ -129,10 +129,10 @@ impl crate::Readable for DELAY0_SPEC {
 impl crate::Writable for DELAY0_SPEC {
     type Writer = W;
 }
-#[doc = "`reset()` method sets delay0 to value 0x0101"]
+#[doc = "`reset()` method sets delay0 to value 0x0001_0001"]
 impl crate::Resettable for DELAY0_SPEC {
     #[inline(always)]
     fn reset_value() -> Self::Ux {
-        0x0101
+        0x0001_0001
     }
 }

--- a/src/common/qspi0/delay0.rs
+++ b/src/common/qspi0/delay0.rs
@@ -129,10 +129,10 @@ impl crate::Readable for DELAY0_SPEC {
 impl crate::Writable for DELAY0_SPEC {
     type Writer = W;
 }
-#[doc = "`reset()` method sets delay0 to value 0"]
+#[doc = "`reset()` method sets delay0 to value 0x0101"]
 impl crate::Resettable for DELAY0_SPEC {
     #[inline(always)]
     fn reset_value() -> Self::Ux {
-        0
+        0x0101
     }
 }

--- a/src/common/qspi0/delay1.rs
+++ b/src/common/qspi0/delay1.rs
@@ -129,10 +129,10 @@ impl crate::Readable for DELAY1_SPEC {
 impl crate::Writable for DELAY1_SPEC {
     type Writer = W;
 }
-#[doc = "`reset()` method sets delay1 to value 0"]
+#[doc = "`reset()` method sets delay1 to value 0x01"]
 impl crate::Resettable for DELAY1_SPEC {
     #[inline(always)]
     fn reset_value() -> Self::Ux {
-        0
+        0x01
     }
 }


### PR DESCRIPTION
The SPI delay0 and delay1 control registers didn't have their reset value set according to spec. This fixes it.