### PR TITLE
embedded-hal v1.0.0-alpha.8 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "ISC"
 [dependencies]
 bare-metal = "1.0.0"
 vcell = "0.1.3"
-riscv = "0.8.0"
+riscv = "0.9.0-alpha.1"
 
 [features]
 rt = []


### PR DESCRIPTION
Bumps embedded-hal to v1.0.0-alpha.8

Requires:
https://github.com/rust-embedded/riscv-rt/pull/101
https://github.com/rust-embedded/riscv/pull/106