### PR TITLE
feature-gate I2C0 with g002

### DIFF
--- a/e310x/CHANGELOG.md
+++ b/e310x/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- The I2C0 code is now gated under the `g002` feature
 - Regenerate code with `svd2rust` 0.36.1
 - Use `riscv` v0.13.0 and `riscv-rt` v0.14.0
 - In vectored mode, align `mtvec` to 64 bytes

--- a/e310x/e310x.svd
+++ b/e310x/e310x.svd
@@ -16,7 +16,6 @@
     <peripheral>
       <name>CLINT</name>
       <baseAddress>0x02000000</baseAddress>
-      <groupName>CLINT</groupName>
       <description>Coreplex Local Interrupts</description>
       <registers>
         <register>
@@ -58,7 +57,6 @@
     <peripheral>
       <name>PLIC</name>
       <baseAddress>0x0C000000</baseAddress>
-      <groupName>PLIC</groupName>
       <description>Platform Level Interrupt Control</description>
       <registers>
         <register>
@@ -200,7 +198,6 @@
     <peripheral>
       <name>WDOG</name>
       <baseAddress>0x10000000</baseAddress>
-      <groupName>Watchdog</groupName>
       <description>Watchdog</description>
       <registers>
         <register>
@@ -258,7 +255,6 @@
     <peripheral>
       <name>RTC</name>
       <baseAddress>0x10000000</baseAddress>
-      <groupName>Watchdog</groupName>
       <description>Watchdog</description>
       <registers>
         <register>
@@ -306,7 +302,6 @@
     <peripheral>
       <name>AONCLK</name>
       <baseAddress>0x10000000</baseAddress>
-      <groupName>AONCLOCK</groupName>
       <description>Always-On Clock Configuration</description>
       <registers>
         <register>
@@ -328,7 +323,6 @@
     <peripheral>
       <name>BACKUP</name>
       <baseAddress>0x10000000</baseAddress>
-      <groupName>BACKUP</groupName>
       <description>Backup Registers</description>
       <registers>
         <register>
@@ -346,7 +340,6 @@
     <peripheral>
       <name>PMU</name>
       <baseAddress>0x10000000</baseAddress>
-      <groupName>PMU</groupName>
       <description>PMU</description>
       <registers>
         <register>
@@ -461,7 +454,6 @@
     <peripheral>
       <name>PRCI</name>
       <baseAddress>0x10008000</baseAddress>
-      <groupName>PRCI</groupName>
       <description>Power Reset Clock Interrupts</description>
       <registers>
         <register>
@@ -565,7 +557,6 @@
       <name>OTP</name>
       <baseAddress>0x10010000</baseAddress>
 
-      <groupName>OTP</groupName>
       <description>One Time Programmable Memory</description>
 
       <registers>
@@ -648,7 +639,6 @@
       <name>GPIO0</name>
       <baseAddress>0x10012000</baseAddress>
 
-      <groupName>GPIO</groupName>
       <description>General Purpose Input Output</description>
 
       <registers>
@@ -1660,7 +1650,6 @@
       <name>UART0</name>
       <baseAddress>0x10013000</baseAddress>
 
-      <groupName>UART</groupName>
       <description>Universal Asynchronous Receiver Transmitter</description>
 
       <registers>
@@ -1755,7 +1744,6 @@
       <name>QSPI0</name>
       <baseAddress>0x10014000</baseAddress>
 
-      <groupName>QSPI</groupName>
       <description>Quad Serial Peripheral Interface</description>
 
       <registers>
@@ -2166,7 +2154,6 @@
       <name>PWM0</name>
       <baseAddress>0x10015000</baseAddress>
 
-      <groupName>PWM</groupName>
       <description>8-bit timer with 4 cmp</description>
 
       <registers>
@@ -2269,7 +2256,7 @@
     <peripheral>
       <name>I2C0</name>
       <baseAddress>0x10016000</baseAddress>
-      <groupName>I2C</groupName>
+      <groupName>g002</groupName>
       <description>Inter-Integrated Circuit Master Interface (FE310-G002 only)</description>
       <registers>
         <register>

--- a/e310x/src/lib.rs
+++ b/e310x/src/lib.rs
@@ -111,13 +111,16 @@ impl core::fmt::Debug for Pwm0 {
 #[doc = "8-bit timer with 4 cmp"]
 pub mod pwm0;
 #[doc = "Inter-Integrated Circuit Master Interface (FE310-G002 only)"]
+#[cfg(feature = "g002")]
 pub type I2c0 = crate::Periph<i2c0::RegisterBlock, 0x1001_6000>;
+#[cfg(feature = "g002")]
 impl core::fmt::Debug for I2c0 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("I2c0").finish()
     }
 }
 #[doc = "Inter-Integrated Circuit Master Interface (FE310-G002 only)"]
+#[cfg(feature = "g002")]
 pub mod i2c0;
 #[doc = "Universal Asynchronous Receiver Transmitter"]
 pub type Uart1 = crate::Periph<uart0::RegisterBlock, 0x1002_3000>;
@@ -192,6 +195,7 @@ pub struct Peripherals {
     #[doc = "PWM0"]
     pub pwm0: Pwm0,
     #[doc = "I2C0"]
+    #[cfg(feature = "g002")]
     pub i2c0: I2c0,
     #[doc = "UART1"]
     pub uart1: Uart1,
@@ -236,6 +240,7 @@ impl Peripherals {
             uart0: Uart0::steal(),
             qspi0: Qspi0::steal(),
             pwm0: Pwm0::steal(),
+            #[cfg(feature = "g002")]
             i2c0: I2c0::steal(),
             uart1: Uart1::steal(),
             qspi1: Qspi1::steal(),

--- a/e310x/update.sh
+++ b/e310x/update.sh
@@ -2,10 +2,11 @@
 set -x
 set -e
 
-# used svd2rust 0.34.0
+# used svd2rust 0.36.1
 rm -rf src
 mkdir src
-svd2rust --target riscv --settings settings.yaml -g -i e310x.svd
+svd2rust --target riscv --settings settings.yaml --feature-group -g -i e310x.svd
+rm -f features.toml
 mv generic.rs src/
 form -i lib.rs -o src/
 rm lib.rs


### PR DESCRIPTION
I noticed the code for I2C0 was not feature-gated when the `g002` was disabled. Using groups in the SVD file can fix this